### PR TITLE
Save msg_hash to messages table and rename messages route to query with hash

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -76,7 +76,8 @@ router.post('/message', async (req, res) => {
       ts: msg.timestamp,
       payload: JSON.stringify(req.body),
       network,
-      env
+      env,
+      msg_hash: hash
     };
     await db.queryAsync('INSERT IGNORE INTO messages SET ?', params);
     console.log('Received', params);

--- a/src/api.ts
+++ b/src/api.ts
@@ -48,10 +48,10 @@ router.get('/', async (req, res) => {
   });
 });
 
-router.get('/messages/:address', async (req, res) => {
+router.get('/messages/:hash', async (req, res) => {
   try {
-    const address = getAddress(req.params.address);
-    const results = await db.queryAsync('SELECT * FROM messages WHERE address = ?', [address]);
+    const { hash } = req.params;
+    const results = await db.queryAsync('SELECT * FROM messages WHERE msg_hash = ?', [hash]);
     return res.json(results);
   } catch (e) {
     console.log(e);
@@ -73,11 +73,11 @@ router.post('/message', async (req, res) => {
     const params = {
       address,
       hash: safeHash,
+      msg_hash: hash,
       ts: msg.timestamp,
       payload: JSON.stringify(req.body),
       network,
-      env,
-      msg_hash: hash
+      env
     };
     await db.queryAsync('INSERT IGNORE INTO messages SET ?', params);
     console.log('Received', params);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -6,6 +6,6 @@ CREATE TABLE messages (
   payload JSON NOT NULL,
   network VARCHAR(24) NOT NULL,
   env VARCHAR(24) NOT NULL,
-  PRIMARY KEY (address, hash, msg_hash),
+  PRIMARY KEY (address, hash),
   INDEX ts (ts)
 );

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,10 +1,11 @@
 CREATE TABLE messages (
   address VARCHAR(42) NOT NULL,
   hash VARCHAR(66) NOT NULL,
+  msg_hash VARCHAR(66) NOT NULL,
   ts BIGINT NOT NULL,
   payload JSON NOT NULL,
   network VARCHAR(24) NOT NULL,
   env VARCHAR(24) NOT NULL,
-  PRIMARY KEY (address, hash),
+  PRIMARY KEY (address, hash, msg_hash),
   INDEX ts (ts)
 );

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -7,5 +7,6 @@ CREATE TABLE messages (
   network VARCHAR(24) NOT NULL,
   env VARCHAR(24) NOT NULL,
   PRIMARY KEY (address, hash),
-  INDEX ts (ts)
+  INDEX ts (ts),
+  INDEX msg_hash (msg_hash)
 );


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-relayer/issues/49

Admin tasks: 

- [x] Run this:
```sql
ALTER table messages add msg_hash varchar(66) not null after hash;
Alter table messages add index msg_hash (msg_hash);
```