### PR TITLE
fix: return a 400 error on invalid address

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -72,10 +72,18 @@ router.post('/', async (req, res) => {
     });
   }
 
+  let address;
+  try {
+    address = getAddress(req.body.address);
+  } catch (e: any) {
+    return res.status(400).json({
+      error: 'Invalid address'
+    });
+  }
+
   try {
     const msg = req.body.data.message;
     const msgHash = snapshot.utils.getHash(req.body.data);
-    const address = getAddress(req.body.address);
     const env = 'livenet';
     let network = env === 'livenet' ? '1' : '5';
     if (!req.body.data.types.Space && !msg.settings)


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When using submit a POST with an invalid address, it returns a 500 error.
User input error should throw a 400 error, and should not be logged as an error in the error monitoring system.

## 💊 Fixes / Solution

Fix #137 
Fix [SNAPSHOT-RELAYER-3](https://snapshot-labs.sentry.io/issues/4416497232/?referrer=github_integration)

Fail early on invalid address, and return a 400 error

## 🚧 Changes

- Check for address validity early, and fail with 400 code on invalid address
- Do not log invalid address error on Sentry

## 🛠️ Tests

- N/A