### PR TITLE
fix: fix error when msg.space is empty

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -66,14 +66,21 @@ router.get('/api/messages/:hash', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
+  const msg = req.body.data.message;
+
   if (!req.body.data || !req.body.data.message) {
     return res.status(400).json({
       error: 'Invalid format request'
     });
   }
 
+  if (!req.body.data.types.Space && !msg.settings && !msg.space) {
+    return res.status(400).json({
+      error: 'Missing space'
+    });
+  }
+
   try {
-    const msg = req.body.data.message;
     const msgHash = snapshot.utils.getHash(req.body.data);
     const address = getAddress(req.body.address);
     const env = 'livenet';

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,13 +66,14 @@ router.get('/api/messages/:hash', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  if (!req.body.data || !req.body.data.message) {
+  const msg = req.body.data?.message;
+
+  if (!msg) {
     return res.status(400).json({
       error: 'Invalid format request'
     });
   }
 
-  const msg = req.body.data.message;
   if (!req.body.data.types.Space && !msg.settings && !msg.space) {
     return res.status(400).json({
       error: 'Missing space'

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,14 +66,13 @@ router.get('/api/messages/:hash', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const msg = req.body.data.message;
-
   if (!req.body.data || !req.body.data.message) {
     return res.status(400).json({
       error: 'Invalid format request'
     });
   }
 
+  const msg = req.body.data.message;
   if (!req.body.data.types.Space && !msg.settings && !msg.space) {
     return res.status(400).json({
       error: 'Missing space'


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When an user is submitting a payload with an empty `msg.space`, the subgraph query using that space as argument is failing with the error https://snapshot-labs.sentry.io/issues/4401679917/?referrer=github_integration

## 💊 Fixes / Solution

Fix #139 
Fix [SNAPSHOT-RELAYER-1](https://snapshot-labs.sentry.io/issues/4401679917/?referrer=github_integration)

## 🚧 Changes

- Check and return a 400 error when user is submitting an invalid payload (missing msg.space)

## 🛠️ Tests

- N/A
