### PR TITLE
fix: use keep alive for connection to sequencer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@snapshot-labs/prettier-config": "^0.1.0-beta.11",
     "@types/express": "^4.17.11",
     "@types/jest": "^29.5.3",
-    "@types/node": "^14.14.21",
+    "@types/node": "^16.0.0",
     "@types/node-fetch": "^2.6.4",
     "@types/supertest": "^2.0.12",
     "dotenv-cli": "^7.3.0",

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,5 +1,5 @@
 import snapshot from '@snapshot-labs/snapshot.js';
-import fetch from 'node-fetch';
+import { fetchWithKeepAlive } from './utils';
 import db from './mysql';
 // TODO: remove when all environments are updated
 import constants from './constants.json';
@@ -33,7 +33,7 @@ async function send(body, env = 'livenet') {
     },
     body
   };
-  const res = await fetch(url, init);
+  const res = await fetchWithKeepAlive(url, init);
   return res.json();
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import https from 'node:https';
+import fetch from 'node-fetch';
 import { Contract } from '@ethersproject/contracts';
 import { hexValue } from '@ethersproject/bytes';
 import snapshot from '@snapshot-labs/snapshot.js';
@@ -11,3 +13,9 @@ export async function getSafeVersion(safe, network) {
   const contract = new Contract(hexValue(storage), abi, provider);
   return await contract.VERSION([]);
 }
+
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+export const fetchWithKeepAlive = (uri: any, options: any = {}) => {
+  return fetch(uri, { agent: httpsAgent, ...options });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,10 +1290,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.14.21":
+"@types/node@*":
   version "14.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.17.tgz#4ec7b71bbcb01a4e55455b60b18b1b6a783fe31d"
   integrity sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==
+
+"@types/node@^16.0.0":
+  version "16.18.58"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.58.tgz#bf66f63983104ed57c754f4e84ccaf16f8235adb"
+  integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
 
 "@types/qs@*":
   version "6.9.7"


### PR DESCRIPTION
Fix #167 

Use keep alive connections for connections to sequencer, and avoid error 504