### PR TITLE
chore: move CI to Node 22

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -5,7 +5,11 @@ on:
       - 'master'
 jobs:
   create-sentry-release:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     with:
       project: snapshot-relayer
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,10 @@ on: [push]
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+    with:
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,12 @@ on: [push]
 
 jobs:
   test:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
     secrets: inherit
     with:
+      target: ${{ matrix.target }}
       mysql_database_name: snapshot_relayer_test
       mysql_schema_path: ./src/schema.sql

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "start-server-and-test": "^2.0.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1"
+  },
+  "engines": {
+    "node": ">=22.6.0"
   }
 }


### PR DESCRIPTION
## What

Move CI to Node 22 (Active LTS until Apr 2027):

- Workflow `target` set to `'22'` on lint, test, and create-sentry-release

## Why

Node 18 is EOL. Newer `@snapshot-labs/eslint-config` requires `eslint-visitor-keys@5` whose engine needs `^20.19.0 || ^22.13.0 || >=24` — bumping CI to Node 22 unblocks the dependabot bump. Matches `blockfinder#505` (already merged) and `sx-monorepo` (already on Node 22).

## Test

CI `lint (22)` + `test (22)` should both go green on Node 22.