### PR TITLE
style: apply prettier printWidth 80

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     allow:
       # Allow updates for snapshot.js only
-      - dependency-name: "@snapshot-labs/*"
+      - dependency-name: '@snapshot-labs/*'
     groups:
       snapshot:
         patterns:
-          - "@snapshot-labs/*"
+          - '@snapshot-labs/*'

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,11 @@ export default {
   collectCoverageFrom: ['./src/**'],
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
-  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/dist/',
+    '<rootDir>/test/fixtures/'
+  ],
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-node-single-context',
   setupFiles: ['dotenv/config'],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.17",
-    "@snapshot-labs/prettier-config": "^0.1.0-beta.17",
+    "@snapshot-labs/prettier-config": "^0.1.0",
     "@types/express": "^4.17.11",
     "@types/jest": "^29.5.3",
     "@types/node": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,10 +1117,10 @@
   dependencies:
     "@snapshot-labs/eslint-config-base" "^0.1.0-beta.17"
 
-"@snapshot-labs/prettier-config@^0.1.0-beta.17":
-  version "0.1.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.17.tgz#ded7d95d31c53be21c2e1d30322e02c3534a6a74"
-  integrity sha512-G2XcHaeLFEvmOtniqbNPNfAFT5g/UIKefRHGqUuSd6sSJp3zHqbpplPdID0IsPaDxu6mJu+UYiLW2ohoB7WauQ==
+"@snapshot-labs/prettier-config@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0.tgz#f0eafa4a3aed6a7fabaf88c016659f3343041071"
+  integrity sha512-8MYAHuewlAdJs55f94qQtEs/WLFmjgYfuIVb1iJPa9gUZauHEXMzbVpKZfnkQsgpwwcXxq9hzg0S/OeOkgj3+w==
 
 "@snapshot-labs/snapshot-metrics@^1.4.1":
   version "1.4.1"


### PR DESCRIPTION
Bumps `@snapshot-labs/prettier-config` from `^0.1.0-beta.17` to `^0.1.0`, which leaves Prettier's default `printWidth` of 80 (the `0.1.0` config sets no `printWidth`), and reflows the repo with `prettier --write`.

This is split out from the upcoming **ESLint 9 flat config migration** so that the formatting/reflow churn is isolated and easy to review on its own. The ESLint 9 PR is stacked on top of this branch and will contain only ESLint-related changes.

### Changes
- `@snapshot-labs/prettier-config` → `^0.1.0` (resolves to `0.1.0`, no `printWidth` → default 80)
- Regenerated `yarn.lock`
- `prettier --write` across the repo (minor reflow in `.github/dependabot.yml` and `jest.config.ts`; source files were already compliant)

### Validation (ESLint 8, unchanged on this branch)
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅ (3 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)