### PR TITLE
refactor: align dotenv loading with snapshot-labs convention

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import './instrument';
 import { fallbackLogger } from '@snapshot-labs/snapshot-sentry';
 import bodyParser from 'body-parser';

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,7 +1,6 @@
-import 'dotenv/config';
 import { initLogger } from '@snapshot-labs/snapshot-sentry';
 
 // Since @sentry/node v8, Sentry uses OpenTelemetry-based auto-instrumentation,
 // so initLogger() must run before any instrumented module (http, express, ...)
-// is imported. This file is loaded as the very first import in index.ts.
+// is imported. This file is loaded as the first import in index.ts.
 initLogger();


### PR DESCRIPTION
## What

Follow-up to #362. Aligns the Sentry instrument pattern with the convention used by `hub` and `sequencer` in the monorepo:

- `import 'dotenv/config'` stays as the **first import in `index.ts`** (separate line).
- `instrument.ts` is reduced to just `initLogger()`.

## Why

#362 folded `dotenv/config` inside `instrument.ts`. That's functionally identical — env is loaded before `initLogger()` runs either way — but the other snapshot-labs services keep dotenv as a standalone first import with `instrument.ts` containing only `initLogger()`. This keeps the pattern consistent across repos.

No behavior change.

## Verification

- `yarn typecheck`, `yarn build`, `eslint` on changed files — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)