### PR TITLE
feat: purge dead messages older than the processing window

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -1,6 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
-import { and, eq, gt, inArray } from 'drizzle-orm';
+import { and, eq, gt, inArray, lte } from 'drizzle-orm';
 // TODO: remove when all environments are updated
 import constants from './constants.json';
 import { db } from './db';
@@ -9,6 +9,12 @@ import { messages } from './schema';
 
 const delay = 60 * 60 * 24 * 6; // 6 days
 const interval = 15e3;
+const cleanupInterval = 60 * 60 * 24 * 1e3; // once per day
+let lastCleanup = 0;
+
+export function deadMessageCutoff(now = Date.now()) {
+  return parseInt((now / 1e3).toFixed()) - delay;
+}
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
 const SUPPORTED_NETWORKS = [
@@ -139,7 +145,14 @@ export async function processSigs() {
 
   try {
     // Get all messages from last 6 days and filter by supported networks
-    const ts = parseInt((Date.now() / 1e3).toFixed()) - delay;
+    const ts = deadMessageCutoff();
+
+    if (Date.now() - lastCleanup > cleanupInterval) {
+      lastCleanup = Date.now();
+      const purged = await db.delete(messages).where(lte(messages.ts, ts));
+      console.log('[processSigs] Purged dead messages:', purged.rowCount ?? 0);
+    }
+
     const pending = await db.query.messages.findMany({
       columns: { address: true, hash: true, network: true },
       where: and(

--- a/test/unit/check.test.ts
+++ b/test/unit/check.test.ts
@@ -1,0 +1,18 @@
+import { deadMessageCutoff } from '../../src/check';
+
+const SIX_DAYS = 60 * 60 * 24 * 6;
+
+describe('deadMessageCutoff', () => {
+  it('returns the timestamp 6 days before now', () => {
+    const now = 1_700_000_000_000;
+    expect(deadMessageCutoff(now)).toBe(now / 1e3 - SIX_DAYS);
+  });
+
+  it('matches the processing window, so the purge only removes ignored rows', () => {
+    const now = Date.now();
+    const cutoff = deadMessageCutoff(now);
+    const nowSec = parseInt((now / 1e3).toFixed());
+    // Loop keeps ts > cutoff; purge removes ts <= cutoff (>= 6 days old).
+    expect(nowSec - cutoff).toBe(SIX_DAYS);
+  });
+});


### PR DESCRIPTION
## What

The relayer stores incoming Safe signature messages in Postgres and processes them for 6 days. When a message gets signed on-chain we delete its row, but messages that never get signed just age out: the processing loop only ever looks at rows newer than 6 days (`gt(messages.ts, now - delay)`), so anything older is silently ignored and sits in the table forever. Over time the `messages` table only grows.

This adds a periodic cleanup inside the existing `processSigs` loop that deletes rows past that same 6-day window. The cutoff is derived from the exact same `deadMessageCutoff()` value the processing query uses, so the purge can only ever remove rows the loop already ignores. It's guarded by a timestamp so it runs at most once per day rather than on every 15s tick.

No separate one-time migration is needed: the first cleanup run deletes every row already older than the window, which is the one-time backfill purge. From then on it just trims the daily tail.

## How to test

- `yarn typecheck`, `yarn lint` green.
- `deadMessageCutoff` has a unit test (`test/unit/check.test.ts`) asserting the cutoff is exactly 6 days before now and matches the processing window.
- Locally you can seed a row with `ts` older than `now - 6 days`, run the loop once, and confirm the row is gone and the log prints `[processSigs] Purged dead messages: N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)