### PR TITLE
refactor(db): replace varchar columns with text

### DIFF
--- a/drizzle/0001_needy_invaders.sql
+++ b/drizzle/0001_needy_invaders.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "messages" ALTER COLUMN "address" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "hash" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "msg_hash" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "network" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "env" SET DATA TYPE text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,113 @@
+{
+  "id": "df21b4bd-848c-4b75-9e25-693b40ef0067",
+  "prevId": "8d8be1c7-a3cf-4e09-b388-30c36e340c56",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "msg_hash": {
+          "name": "msg_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_ts_idx": {
+          "name": "messages_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_msg_hash_idx": {
+          "name": "messages_msg_hash_idx",
+          "columns": [
+            {
+              "expression": "msg_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "messages_address_hash_pk": {
+          "name": "messages_address_hash_pk",
+          "columns": [
+            "address",
+            "hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784515045459,
       "tag": "0000_dapper_aaron_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784730737415,
+      "tag": "0001_needy_invaders",
+      "breakpoints": true
     }
   ]
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,25 +1,18 @@
-import {
-  bigint,
-  index,
-  pgTable,
-  primaryKey,
-  text,
-  varchar
-} from 'drizzle-orm/pg-core';
+import { bigint, index, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
 
 export const messages = pgTable(
   'messages',
   {
-    address: varchar({ length: 42 }).notNull(),
-    hash: varchar({ length: 66 }).notNull(),
+    address: text().notNull(),
+    hash: text().notNull(),
     // snake_case to preserve the JSON shape served by GET /api/messages/:hash
-    msg_hash: varchar({ length: 66 }).notNull(),
+    msg_hash: text().notNull(),
     ts: bigint({ mode: 'number' }).notNull(),
     // Opaque JSON string relayed verbatim to the sequencer and
     // GET /api/messages/:hash; text keeps it byte-for-byte.
     payload: text().notNull(),
-    network: varchar({ length: 24 }).notNull(),
-    env: varchar({ length: 24 }).notNull()
+    network: text().notNull(),
+    env: text().notNull()
   },
   table => [
     primaryKey({ columns: [table.address, table.hash] }),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,11 +5,10 @@ export const messages = pgTable(
   {
     address: text().notNull(),
     hash: text().notNull(),
-    // snake_case to preserve the JSON shape served by GET /api/messages/:hash
+    // snake_case: key is served as-is by GET /api/messages/:hash
     msg_hash: text().notNull(),
     ts: bigint({ mode: 'number' }).notNull(),
-    // Opaque JSON string relayed verbatim to the sequencer and
-    // GET /api/messages/:hash; text keeps it byte-for-byte.
+    // text, not json: relayed verbatim, byte-for-byte
     payload: text().notNull(),
     network: text().notNull(),
     env: text().notNull()


### PR DESCRIPTION
Removes last MySQL holdover from #367: arbitrary `varchar(n)` caps → plain `text` (Postgres convention, no perf difference).

- `src/schema.ts`: all 5 varchar columns → `text`
- `drizzle/0001`: `ALTER COLUMN ... SET DATA TYPE text` — metadata-only, no table rewrite, safe on live data

Kept as-is: `ts` bigint epoch (GET /api/messages/:hash serves rows verbatim, API shape unchanged), `payload` text (opaque JSON relayed byte-for-byte).

Dropped length caps will return as app-layer validation: #370