### PR TITLE
chore(deps): bump typescript from 4.7 to 5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pg": "^8.13.1",
     "semver": "^7.3.5",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,10 +5980,10 @@ typescript-eslint@^8.29.1:
     "@typescript-eslint/typescript-estree" "8.61.1"
     "@typescript-eslint/utils" "8.61.1"
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undefsafe@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
Bumps `typescript` to `^5.9.3`, aligning with sx-monorepo (5.8/5.9).

TS 6/7 deferred: `ts-jest` and `@snapshot-labs/eslint-config` peer ranges cap at `<6`.

- `yarn typecheck`, `yarn build`, `yarn lint` pass
- e2e untouched; ts-jest 29.1.1 supports TS 5.9