### PR TITLE
fix(db): survive Postgres terminating an idle pooled connection

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -11,20 +11,12 @@ export const db = drizzle({
     connectionString: process.env.DATABASE_URL,
     connectionTimeoutMillis: 60e3,
     query_timeout: 60e3,
-    // Long enough to keep the 15s processSigs poller on a warm connection,
-    // short enough that a connection is not left idle for the server to reap.
     idleTimeoutMillis: 30e3,
     keepAlive: true
   },
   schema
 });
 
-// A pooled connection that the server kills while it sits idle (failover,
-// maintenance, pg_terminate_backend) is re-emitted by pg-pool as an 'error' on
-// the pool. 'error' is the one EventEmitter event that throws when nobody is
-// listening, so with no handler here the process dies on uncaughtException.
-// pg-pool has already removed the dead client by this point and the next query
-// opens a fresh one, so logging and carrying on is the correct response.
 db.$client.on('error', err => console.log('[db] pool error', err));
 
 export async function runMigrations() {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,3 +1,4 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import * as schema from './schema';
@@ -17,7 +18,7 @@ export const db = drizzle({
   schema
 });
 
-db.$client.on('error', err => console.log('[db] pool error', err));
+db.$client.on('error', err => capture(err));
 
 export async function runMigrations() {
   await migrate(db, { migrationsFolder: 'drizzle' });

--- a/src/db.ts
+++ b/src/db.ts
@@ -11,11 +11,21 @@ export const db = drizzle({
     connectionString: process.env.DATABASE_URL,
     connectionTimeoutMillis: 60e3,
     query_timeout: 60e3,
-    idleTimeoutMillis: 0,
+    // Long enough to keep the 15s processSigs poller on a warm connection,
+    // short enough that a connection is not left idle for the server to reap.
+    idleTimeoutMillis: 30e3,
     keepAlive: true
   },
   schema
 });
+
+// A pooled connection that the server kills while it sits idle (failover,
+// maintenance, pg_terminate_backend) is re-emitted by pg-pool as an 'error' on
+// the pool. 'error' is the one EventEmitter event that throws when nobody is
+// listening, so with no handler here the process dies on uncaughtException.
+// pg-pool has already removed the dead client by this point and the next query
+// opens a fresh one, so logging and carrying on is the correct response.
+db.$client.on('error', err => console.log('[db] pool error', err));
 
 export async function runMigrations() {
   await migrate(db, { migrationsFolder: 'drizzle' });

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -1,12 +1,14 @@
 process.env.DATABASE_URL ??=
   'postgres://postgres:postgres@127.0.0.1:5432/snapshot_relayer_test';
 
+const mockCapture = jest.fn();
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: (...args: any[]) => mockCapture(...args)
+}));
+
 describe('db', () => {
   describe('pool error handling', () => {
     it('does not throw when the pool emits an error', async () => {
-      const log = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => undefined);
       const { db } = await import('../../src/db');
 
       expect(db.$client.listenerCount('error')).toBe(1);
@@ -16,9 +18,22 @@ describe('db', () => {
           new Error('terminating connection due to administrator command')
         )
       ).not.toThrow();
-      expect(log).toHaveBeenCalled();
+    });
 
-      log.mockRestore();
+    it('captures the pool error unchanged, including a 57P01 shutdown', async () => {
+      const { db } = await import('../../src/db');
+      const err: any = new Error(
+        'terminating connection due to administrator command'
+      );
+      err.code = '57P01';
+      err.severity = 'FATAL';
+
+      mockCapture.mockClear();
+      db.$client.emit('error', err);
+
+      expect(mockCapture).toHaveBeenCalledTimes(1);
+      expect(mockCapture).toHaveBeenCalledWith(err);
+      expect(mockCapture.mock.calls[0][0].code).toBe('57P01');
     });
   });
 });

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -1,5 +1,3 @@
-// node-postgres opens connections lazily, so building the pool here does not
-// need a live database.
 process.env.DATABASE_URL ??=
   'postgres://postgres:postgres@127.0.0.1:5432/snapshot_relayer_test';
 
@@ -11,9 +9,6 @@ describe('db', () => {
         .mockImplementation(() => undefined);
       const { db } = await import('../../src/db');
 
-      // A pooled connection killed server-side while idle is re-emitted by
-      // pg-pool as an 'error' event on the pool. EventEmitter rethrows that
-      // event when nothing listens for it, which takes the process down.
       expect(db.$client.listenerCount('error')).toBe(1);
       expect(() =>
         db.$client.emit(

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -1,0 +1,29 @@
+// node-postgres opens connections lazily, so building the pool here does not
+// need a live database.
+process.env.DATABASE_URL ??=
+  'postgres://postgres:postgres@127.0.0.1:5432/snapshot_relayer_test';
+
+describe('db', () => {
+  describe('pool error handling', () => {
+    it('does not throw when the pool emits an error', async () => {
+      const log = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined);
+      const { db } = await import('../../src/db');
+
+      // A pooled connection killed server-side while idle is re-emitted by
+      // pg-pool as an 'error' event on the pool. EventEmitter rethrows that
+      // event when nothing listens for it, which takes the process down.
+      expect(db.$client.listenerCount('error')).toBe(1);
+      expect(() =>
+        db.$client.emit(
+          'error',
+          new Error('terminating connection due to administrator command')
+        )
+      ).not.toThrow();
+      expect(log).toHaveBeenCalled();
+
+      log.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #379
Fixes SNAPSHOT-RELAYER-Y

## Root cause

`src/db.ts` builds the node-postgres `Pool` implicitly through `drizzle({ connection: {...} })` and never attaches a pool `'error'` listener.

When Postgres terminates a connection that is sitting **idle** in the pool (failover, maintenance, `pg_terminate_backend`), pg-pool's `idleListener` removes the dead client and re-emits the error on the pool:

```js
// node_modules/pg-pool/index.js:51-64
function makeIdleListener(pool, client) {
  return function idleListener(err) {
    ...
    pool._remove(client)
    pool.emit('error', err, client)   // <- line 62
  }
}
```

`'error'` is the one EventEmitter event that **throws** when nothing is listening. The throw happens inside a socket read callback, so it surfaces as an uncaughtException and the process dies. That is the `auto.node.onuncaughtexception` mechanism on the Sentry event.

`idleTimeoutMillis: 0` widened the window rather than causing it: idle connections were never recycled client-side, so a pooled connection was always available for the server to reap.

This is **not** a swallowed rejection, an unawaited promise, or connection exhaustion. Only the idle path is fatal — with one qualification I stated too flatly before.

A connection killed *mid-query* is fine **because neither repo uses transactions**. `pool.query()` attaches its own listener for the duration of the query (`pg-pool/index.js`, `client.once('error', onError)`), so the failure rejects the query promise and every call site already handles it. `pool.connect()` does **not** self-protect the same way: `_acquireClient` removes the idle listener (`pg-pool/index.js:344`) and puts nothing in its place, so a client checked out that way carries zero `'error'` listeners — and the pool-level listener this PR adds does not cover it. Measured on this branch against local Postgres:

```
=== A: pool.query() with the backend killed mid-query ===
   query promise REJECTED -> catchable at the call site
   code: "57P01" | message: terminating connection due to administrator command
   process still alive: true

=== B: pool.connect() client killed while checked out (the .transaction() path) ===
   listeners on the CLIENT for "error": 0
   listeners on the POOL for "error": 1

*** uncaughtException ***
    DatabaseError "57P01" terminating connection due to administrator command
    => a pool "error" listener did NOT protect this path
```

drizzle's `.transaction()` takes exactly that path (`drizzle-orm/node-postgres/session.cjs:217`, `await this.client.connect()`). Neither repo calls `.transaction()` today, so the claim holds — but it holds by accident, and the first transaction added here would reopen #379 on a path this listener does not guard.

Identical code, identical crash, in `snapshot-labs/envelop` 21 minutes earlier the same evening — same fix in snapshot-labs/envelop#306. The two `src/db.ts` files were byte-identical.

## Reproduction

Local Postgres 16.14, real service (`node dist/src/index.js`) against `snapshot_relayer_test`, then `pg_terminate_backend` on the idle backend.

**Before** (`fff7ddf`):

```
--- HTTP probe before kill: 200 ---
  pid   | state
--------+-------
 559027 | idle
--- terminating idle backend(s) ---
 559027 | t
=== RESULT: process 559014 is DEAD ===

node:events:497
      throw er; // Unhandled 'error' event
      ^
error: terminating connection due to administrator command
    at parseErrorMessage (node_modules/pg-protocol/dist/parser.js:305:11)
    ...
Emitted 'error' event on BoundPool instance at:
    at Client.idleListener (node_modules/pg-pool/index.js:62:10)
  severity: 'FATAL',
  code: '57P01',
```

Byte-for-byte the message on the Sentry event.

**After** (this branch), same script, same kill:

```
--- HTTP probe before kill: 200 ---
  pid   | state
--------+-------
 583362 | idle
--- terminating idle backend(s) ---
t
=== RESULT: process 583275 is ALIVE ===
--- HTTP probe after kill: 200 ---

=====[ INTERCEPTED capture -> Sentry ]=====
### CAPTURED OBJECT (argument to Sentry.captureException) ###
  constructor     : DatabaseError
  instanceof Error: true
  message         : terminating connection due to administrator command
  code (SQLSTATE) : "57P01"
  severity        : "FATAL"
  routine         : "ProcessInterrupts"
  stack[1]        : at parseErrorMessage (node_modules/pg-protocol/dist/parser.js:305:11)
  stack[2]        : at Parser.handlePacket (node_modules/pg-protocol/dist/parser.js:143:27)
  captureContext  : undefined
==========================================
```

The process survives, the fault reaches Sentry intact, and the next request transparently opens a new connection. (`Sentry.captureException` is stubbed in that run to print its argument instead of transmitting, so the block above is exactly the object Sentry would receive.)

## Why `idleTimeoutMillis: 30e3`

Secondary hardening, not the fix — the note in the issue is right that a timeout alone cannot help, since the termination is server-initiated.

#367 set `0` on purpose ("keep the poller's db connection warm — pg-pool reaped it between 15s cycles"), because pg-pool's 10s default is shorter than the 15s `processSigs` interval. 30s is above that interval, so the poller keeps its warm connection; measured over 60s of normal running on this branch:

```
### relayer (15s poller) - pooled backend over 60s with idleTimeoutMillis=30e3
t=18s  561123 idle since 2026-08-02 13:49:13.526439+00
t=28s  561123 idle since 2026-08-02 13:49:13.526439+00
t=38s  561123 idle since 2026-08-02 13:49:13.526439+00
t=48s  561123 idle since 2026-08-02 13:49:13.526439+00
t=58s  561123 idle since 2026-08-02 13:49:13.526439+00
t=68s  561123 idle since 2026-08-02 13:49:13.526439+00
```

Same pid throughout: no churn, the #367 intent is preserved. Happy to drop this hunk if you would rather keep the diff to the listener alone.

## Logging vs capturing

Your call on the earlier draft was right, so the handler now does `capture(err)` rather than `console.log`.

Logging meant a pool error was only ever seen by whoever happened to be tailing the logs at that moment. Nothing paged, nothing grouped, no regression was tracked, and a database that was genuinely broken looked exactly like one that was fine.

**Unfiltered, deliberately.** The tempting version skips `57P01` so planned maintenance stays quiet — but an emergency database bounce emits the same SQLSTATE as a planned one, so that filter would silence precisely the case worth waking up for. If the volume turns out to be annoying, that is a Sentry-side grouping/rate decision, not something to drop at the source.

`capture()` falls back to `console.error(e)` when `SENTRY_DSN` is unset, so local and unconfigured environments lose nothing by the switch.

One incidental win: `console.log('[db] pool error', err)` printed **118 lines** per event, because a pg `DatabaseError` carries a live `client` reference and `console.log` walks the whole object graph — connection parameters, socket state and all.

## Tests

`test/unit/db.test.ts` asserts the pool has exactly one `'error'` listener, that emitting on it does not throw, and that the error reaches `capture()` **unchanged** — including a `57P01`, which pins the no-filtering decision so a later refactor cannot quietly reintroduce a skip. It needs no database (node-postgres connects lazily), and it fails on `master`.

## Gates

```
$ yarn lint
$ eslint .
Done in 2.30s.

$ yarn typecheck
$ tsc --noEmit
Done in 4.75s.

$ yarn test
PASS test/unit/db.test.ts (7.302 s)
  db
    pool error handling
      ✓ does not throw when the pool emits an error (160 ms)
      ✓ captures the pool error unchanged, including a 57P01 shutdown (2 ms)
PASS test/e2e/api.test.ts
PASS test/unit/validation.test.ts

Test Suites: 3 passed, 3 total
Tests:       32 passed, 32 total
```


## Out of scope, spotted while in here

Not part of this fix, but worth their own issues:

- **A second unhandled Postgres error on a different path** — now filed as #381 and fixed in #383. `processSig()`'s first `await db.query.messages.findFirst(...)` sat outside its `try`, so a db error there escaped as an unhandled rejection. Correcting what this PR said about it in an earlier draft: it is fatal only *without* a `SENTRY_DSN`. With one set, `Sentry.init()` installs an `unhandledRejection` listener whose mere presence disables Node's fatal default, and its mode defaults to `warn` — so a configured deploy survives, but the report bypasses `capture()` and arrives without the `{ address, safeHash, network }` context. Different mechanism from #379 (`onunhandledrejection`, not `onuncaughtexception`), so it was never visible on SNAPSHOT-RELAYER-Y. #383 is branched off `master` and touches only `src/check.ts`, so it is independent of this PR.
- `@types/pg` is not a dependency and `pg` ships no types of its own, so `db.$client` is typed `any` here (it is properly typed in envelop, which does have `@types/pg`). `tsc` would not have caught a wrong pool API.
- The pre-migration `src/mysql.ts` pinned `connectionLimit = 1`; the pg pool takes node-postgres' default of 10. Almost certainly intended, just noting the behaviour change is unrecorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

