### PR TITLE
fix(check): report a db failure on processSig's first query

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -58,10 +58,10 @@ async function processSig(address, safeHash, network) {
     eq(messages.hash, safeHash),
     eq(messages.network, network)
   );
-  const message = await db.query.messages.findFirst({ where: filter });
-  if (!message) return;
-  console.log('Process sig', network, address, safeHash);
   try {
+    const message = await db.query.messages.findFirst({ where: filter });
+    if (!message) return;
+    console.log('Process sig', network, address, safeHash);
     const result: any = await send(message.payload);
     if (
       result.error_description &&
@@ -92,7 +92,7 @@ async function processSig(address, safeHash, network) {
   }
 }
 
-async function checkSignedMessages(pendingMessages, network) {
+export async function checkSignedMessages(pendingMessages, network) {
   if (pendingMessages.length > 0) {
     const end = timeMessageProcess.startTimer({ network });
     const provider = snapshot.utils.getProvider(network, { broviderUrl });

--- a/test/unit/check.test.ts
+++ b/test/unit/check.test.ts
@@ -1,0 +1,121 @@
+process.env.DATABASE_URL ??=
+  'postgres://postgres:postgres@127.0.0.1:5432/snapshot_relayer_test';
+
+const mockCapture = jest.fn();
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: (...args: any[]) => mockCapture(...args)
+}));
+
+const mockFindFirst = jest.fn();
+const mockDeleteWhere = jest.fn();
+jest.mock('../../src/db', () => ({
+  db: {
+    query: {
+      messages: { findFirst: (...args: any[]) => mockFindFirst(...args) }
+    },
+    delete: () => ({ where: (...args: any[]) => mockDeleteWhere(...args) })
+  }
+}));
+
+jest.mock('../../src/metrics', () => ({
+  timeMessageProcess: { startTimer: () => () => undefined }
+}));
+
+const mockMulticall = jest.fn();
+jest.mock('@snapshot-labs/snapshot.js', () => ({
+  __esModule: true,
+  default: {
+    utils: {
+      getProvider: () => ({}),
+      multicall: (...args: any[]) => mockMulticall(...args),
+      sleep: () => Promise.resolve()
+    }
+  }
+}));
+
+import { checkSignedMessages } from '../../src/check';
+
+const pending = [{ address: '0xabc', hash: '0xdead', network: '1' }];
+
+async function flush() {
+  for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+}
+
+async function withRejectionWatch(fn: () => Promise<void>) {
+  const seen: unknown[] = [];
+  const onRejection = (reason: unknown) => seen.push(reason);
+  process.on('unhandledRejection', onRejection);
+  try {
+    await fn();
+    await flush();
+  } finally {
+    process.off('unhandledRejection', onRejection);
+  }
+  return seen;
+}
+
+describe('checkSignedMessages', () => {
+  beforeEach(() => {
+    mockMulticall.mockResolvedValue(['1']);
+    mockDeleteWhere.mockResolvedValue(undefined);
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: async () => ({}) }) as any;
+  });
+
+  it('reports a db failure on the first query with the message context', async () => {
+    const dbError = new Error('relation "messages" does not exist');
+    mockFindFirst.mockRejectedValue(dbError);
+
+    const rejections = await withRejectionWatch(() =>
+      checkSignedMessages(pending, '1')
+    );
+
+    expect(rejections).toEqual([]);
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith(dbError, {
+      address: '0xabc',
+      safeHash: '0xdead',
+      network: '1'
+    });
+  });
+
+  it('relays and deletes a message that is signed on-chain', async () => {
+    mockFindFirst.mockResolvedValue({ payload: '{}' });
+
+    const rejections = await withRejectionWatch(() =>
+      checkSignedMessages(pending, '1')
+    );
+
+    expect(rejections).toEqual([]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the message is already gone', async () => {
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const rejections = await withRejectionWatch(() =>
+      checkSignedMessages(pending, '1')
+    );
+
+    expect(rejections).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  it('skips messages that are not signed on-chain', async () => {
+    mockMulticall.mockResolvedValue(['0']);
+    mockFindFirst.mockResolvedValue({ payload: '{}' });
+
+    const rejections = await withRejectionWatch(() =>
+      checkSignedMessages(pending, '1')
+    );
+
+    expect(rejections).toEqual([]);
+    expect(mockFindFirst).not.toHaveBeenCalled();
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #381

## The hole

`processSig()` is called fire-and-forget from the `forEach` in `checkSignedMessages()`, and its first `await db.query.messages.findFirst(...)` (`src/check.ts:61` on master) sat *above* the `try` that opens at line 64. A db error on that one query reached none of the three catch blocks on the path, so it escaped as an unhandled promise rejection.

Reproduced on master `fff7ddf` against a local Postgres 16.14, real service (`node dist/src/index.js`). The only thing faked is `snapshot.utils.multicall`, stubbed to report the single pending message as signed (`'1'`) so the `forEach` is reached; the stub also renames `messages` away, which is what a db blip looks like to the very next query.

**Without `SENTRY_DSN`** — nothing listens for `unhandledRejection`, Node 22's fatal default applies:

```
Total messages waiting:  1
[repro] messages table renamed away (simulated DB blip)
Network: 1 - Valid: 1 - Invalid: 0
Done

DrizzleQueryError: Failed query: select "address", "hash", "msg_hash", ... from "messages" ...
    at async processSig (dist/src/check.js:58:21)
  cause: error: relation "messages" does not exist
    code: '42P01',
[repro] EXIT=1
```

Note the ordering: `Done` prints *first*. The cycle reported success; the process died afterwards, out of band.

**With `SENTRY_DSN` set** — the process survives, because `Sentry.init()` installs an `unhandledRejection` listener whose mere presence disables Node's fatal default, and whose `mode` defaults to `warn`. But the report bypasses our `capture()`:

```
Done
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). ...
    at async processSig (dist/src/check.js:58:21)
Process all sigs
```

I instrumented `Sentry.captureException` for that run. The only thing that reached it was the `findMany` at `src/check.ts:143` — the *next* query, which hits the same broken db and *is* caught. Same blip, two different fates, decided only by which side of a `try` the query sits on. The one query whose failure carries no identifying context is the one that says which message was being relayed.

## The fix

**Move the `findFirst` inside the existing `try`.** That is the entire change to `src/check.ts` — four lines shifted, no new control flow. The call site is byte-for-byte what it is on master.

It is the only option that reports the failure with `{ address, safeHash, network }` — the context the catch at `src/check.ts:82` already attaches to every other `processSig` failure.

An earlier revision of this PR also added a `.catch()` at the call site, described as a backstop against the class recurring. @wa0x6e asked for it to be dropped and Copilot independently flagged the same lines; both were right, and it is gone. It could never fire: the inner catch calls `capture()` and falls through, so the promise `processSig()` returns always *resolves*, and a call-site rejection handler is unreachable. The two reproduction runs made with it in place logged its `'[processSig] Unhandled'` line zero times. The only code left above the `try` is three synchronous drizzle expression builders, which do not throw. It was dead code claiming to be a safety net, and its log label said `Unhandled` about something that by construction had just been handled.

**Not chosen: awaiting the calls through `Promise.all`.** It does close the hole, but it has two costs I could measure.

It couples the poll cadence to sequencer latency. With the sequencer POST stubbed to take 8s and one message relayed every cycle:

```
### fire-and-forget (master)                ### await Promise.all
[t=   685ms] Process all sigs               [t=   578ms] Process all sigs
[t=   697ms] Done                           [t=  8594ms] Done
[t= 15697ms] Process all sigs               [t= 23596ms] Process all sigs
[t= 30702ms] Process all sigs               [t= 46603ms] Process all sigs
[t= 45708ms] Process all sigs
```

A 15.0s cycle becomes 23.0s. Today the relay overlaps the sleep; under `Promise.all` the poller waits on every relay before sleeping, and `fetch` here has no timeout of its own.

And on its own it reports *worse* than the one-line move. The rejection lands in `checkSignedMessages()`'s catch, so the same db failure is captured as:

```
captureContext : {"contexts":{"input":{"messages":[{"address":"0x1111...","hash":"0xdead","network":"1"}],"network":"1"}}}
multicall error for network: 1 DrizzleQueryError: Failed query: select ... from "messages" ...
```

Batch-level context instead of the specific message, and a db error logged as `multicall error` when the multicall succeeded.

**Not chosen: a process-level `unhandledRejection` handler.** It treats the symptom, and a blanket handler masks genuine bugs. Worth considering separately if we want the behaviour to be ours rather than a Sentry default, but it is not this fix.

## After

Same reproduction, same blip, re-run at `cf921ea` — that is, against the current branch with the `.catch()` removed, not carried over from the earlier revision.

Without `SENTRY_DSN` — the process survives (exit 124 is my 25s harness timeout, i.e. still polling), and the failure carries its message identity:

```
Total messages waiting:  1
[repro] messages table renamed away (simulated DB blip)
Network: 1 - Valid: 1 - Invalid: 0
Done
[processSig] Failed 1 0x1111111111111111111111111111111111111111 0xdead DrizzleQueryError: Failed query: select "address", "hash", ... from "messages" ...
  cause: error: relation "messages" does not exist
    severity: 'ERROR',
    code: '42P01',
    file: 'parse_relation.c',
    routine: 'parserOpenTable'
Process all sigs
[driver] node exited with 124
```

A real Postgres `42P01`, not a thrown stub. Poll cycles observed: 2 in 25s, unchanged 15s cadence. Unhandled-rejection warnings: 0 (was 1). `[processSig] Unhandled` lines: 0, because that log no longer exists.

With `SENTRY_DSN` — it goes through `capture()`, with the per-message context:

```
=====[ INTERCEPTED capture -> Sentry ]=====
  constructor     : DrizzleQueryError
  instanceof Error: true
  message         : Failed query: select "address", "hash", "msg_hash", ... from "messages" ...
  captureContext  : {"contexts":{"input":{"address":"0x1111111111111111111111111111111111111111","safeHash":"0xdead","network":"1"}}}
==========================================
```

Exactly one `capture()` from `processSig`'s catch, and it is the one carrying `{ address, safeHash, network }`. The run's second `capture()` is the *next* poll cycle's `findMany` in `processSigs()` — the table is still renamed on cycle 2 — which is master's existing, already-caught behaviour and not on this path.

## Tests

`test/unit/check.test.ts` is new and needs no database. `checkSignedMessages` is now exported so the path is reachable from a test; that is the only reason for the `export`, and the only other line this PR touches.

The first test watches `process.on('unhandledRejection')` across the call and asserts both that nothing escaped and that `capture()` was called once with the message context. It fails on master:

```
● checkSignedMessages › reports a db failure on the first query with the message context

    expect(received).toEqual(expected) // deep equality

    - Array []
    + Array [
    +   [Error: relation "messages" does not exist],
    + ]
```

The other three cover the paths that moved into the `try`: a successful relay still deletes the row, an already-deleted message does nothing, and an unsigned message is skipped. `check.ts` line coverage goes 0% -> 74.01%.

## Gates

```
$ yarn lint
$ eslint .
Done in 3.00s.

$ yarn typecheck
$ tsc --noEmit
Done in 5.46s.

$ yarn test
PASS test/unit/check.test.ts (9.639 s)
  checkSignedMessages
    ✓ reports a db failure on the first query with the message context (35 ms)
    ✓ relays and deletes a message that is signed on-chain (3 ms)
    ✓ does nothing when the message is already gone (2 ms)
    ✓ skips messages that are not signed on-chain (2 ms)
PASS test/unit/db.test.ts
PASS test/unit/validation.test.ts
PASS test/e2e/api.test.ts

Test Suites: 4 passed, 4 total
Tests:       36 passed, 36 total
```

Branched off `master` rather than off #380, so the two were independent. Now that #380 has merged, this branch is rebased on top of it — the run above is against current `master` (`4cd168a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
